### PR TITLE
Hotfix/elf parser

### DIFF
--- a/src/core/arm1176jzf_s/cpu_core.cpp
+++ b/src/core/arm1176jzf_s/cpu_core.cpp
@@ -146,22 +146,7 @@ namespace zero_mate::arm1176jzf_s
     {
         for (const auto& instruction : instructions)
         {
-            try
-            {
-                Execute(instruction);
-            }
-            catch (const exceptions::CSoftware_Interrupt& ex)
-            {
-                // TODO
-            }
-            catch (const exceptions::CUndefined_Instruction& ex)
-            {
-                // TODO
-            }
-            catch (const exceptions::CData_Abort& ex)
-            {
-                // TODO
-            }
+            Execute(instruction);
         }
     }
 
@@ -174,55 +159,70 @@ namespace zero_mate::arm1176jzf_s
 
         const auto type = m_instruction_decoder.Get_Instruction_Type(instruction);
 
-        switch (type)
+        try
         {
-            case isa::CInstruction::NType::Data_Processing:
-                Execute(isa::CData_Processing{ instruction });
-                break;
+            switch (type)
+            {
+                case isa::CInstruction::NType::Data_Processing:
+                    Execute(isa::CData_Processing{ instruction });
+                    break;
 
-            case isa::CInstruction::NType::Multiply:
-                Execute(isa::CMultiply{ instruction });
-                break;
+                case isa::CInstruction::NType::Multiply:
+                    Execute(isa::CMultiply{ instruction });
+                    break;
 
-            case isa::CInstruction::NType::Multiply_Long:
-                Execute(isa::CMultiply_Long{ instruction });
-                break;
+                case isa::CInstruction::NType::Multiply_Long:
+                    Execute(isa::CMultiply_Long{ instruction });
+                    break;
 
-            case isa::CInstruction::NType::Branch_And_Exchange:
-                Execute(isa::CBranch_And_Exchange{ instruction });
-                break;
+                case isa::CInstruction::NType::Branch_And_Exchange:
+                    Execute(isa::CBranch_And_Exchange{ instruction });
+                    break;
 
-            case isa::CInstruction::NType::Halfword_Data_Transfer:
-                Execute(isa::CHalfword_Data_Transfer{ instruction });
-                break;
+                case isa::CInstruction::NType::Halfword_Data_Transfer:
+                    Execute(isa::CHalfword_Data_Transfer{ instruction });
+                    break;
 
-            case isa::CInstruction::NType::Single_Data_Transfer:
-                Execute(isa::CSingle_Data_Transfer{ instruction });
-                break;
+                case isa::CInstruction::NType::Single_Data_Transfer:
+                    Execute(isa::CSingle_Data_Transfer{ instruction });
+                    break;
 
-            case isa::CInstruction::NType::Undefined:
-                throw exceptions::CUndefined_Instruction{};
+                case isa::CInstruction::NType::Undefined:
+                    throw exceptions::CUndefined_Instruction{};
 
-            case isa::CInstruction::NType::Block_Data_Transfer:
-                Execute(isa::CBlock_Data_Transfer{ instruction });
-                break;
+                case isa::CInstruction::NType::Block_Data_Transfer:
+                    Execute(isa::CBlock_Data_Transfer{ instruction });
+                    break;
 
-            case isa::CInstruction::NType::Branch:
-                Execute(isa::CBranch{ instruction });
-                break;
+                case isa::CInstruction::NType::Branch:
+                    Execute(isa::CBranch{ instruction });
+                    break;
 
-            case isa::CInstruction::NType::Coprocessor_Data_Transfer:
-                [[fallthrough]];
-            case isa::CInstruction::NType::Coprocessor_Data_Operation:
-            case isa::CInstruction::NType::Coprocessor_Register_Transfer:
-                break;
+                case isa::CInstruction::NType::Coprocessor_Data_Transfer:
+                    [[fallthrough]];
+                case isa::CInstruction::NType::Coprocessor_Data_Operation:
+                case isa::CInstruction::NType::Coprocessor_Register_Transfer:
+                    break;
 
-            case isa::CInstruction::NType::Software_Interrupt:
-                Execute(isa::CSW_Interrupt{ instruction });
-                break;
+                case isa::CInstruction::NType::Software_Interrupt:
+                    Execute(isa::CSW_Interrupt{ instruction });
+                    break;
 
-            case isa::CInstruction::NType::Unknown:
-                throw exceptions::CUndefined_Instruction{};
+                case isa::CInstruction::NType::Unknown:
+                    throw exceptions::CUndefined_Instruction{};
+            }
+        }
+        catch (const exceptions::CSoftware_Interrupt& ex)
+        {
+            // TODO
+        }
+        catch (const exceptions::CUndefined_Instruction& ex)
+        {
+            // TODO
+        }
+        catch (const exceptions::CData_Abort& ex)
+        {
+            // TODO
         }
     }
 

--- a/src/core/utils/elf_loader.cpp
+++ b/src/core/utils/elf_loader.cpp
@@ -4,9 +4,24 @@
 
 namespace zero_mate::utils::elf
 {
+    static inline void Clear_BSS_Section(CBus& bus, const ELFIO::section& section)
+    {
+        for (ELFIO::Elf_Xword i = 0; i < section.get_size(); ++i)
+        {
+            const auto addr = static_cast<std::uint32_t>(section.get_address() + i);
+            bus.Write<std::uint8_t>(addr, 0);
+        }
+    }
+
     static inline void Map_Section_To_RAM(CBus& bus, const ELFIO::section& section)
     {
         const char* data = section.get_data();
+
+        if (data == nullptr)
+        {
+            Clear_BSS_Section(bus, section);
+            return;
+        }
 
         for (ELFIO::Elf_Xword i = 0; i < section.get_size(); ++i)
         {

--- a/src/gui/windows/control_window.cpp
+++ b/src/gui/windows/control_window.cpp
@@ -35,7 +35,7 @@ namespace zero_mate::gui
 
     void CControl_Window::Render_Control_Buttons(bool& running, bool& breakpoint)
     {
-        if (ImGui::Button(ICON_FA_STEP_FORWARD " Next") && !running)
+        if (ImGui::Button(ICON_FA_STEP_FORWARD " Step") && !running)
         {
             m_cpu->Step(true);
         }


### PR DESCRIPTION
Fixed the issue with mapping a BSS section, which was causing a NULL-pointer-related error. It is now being cleared instead. Moved the try-catch block of catching exceptions thrown by the CPU to where it should be. Changed the label of the Next button to Step.